### PR TITLE
Update css.php

### DIFF
--- a/views/default/facebook_theme/css.php
+++ b/views/default/facebook_theme/css.php
@@ -145,8 +145,9 @@ img {max-width:100%}
 }
 
 #facebook-header-login .elgg-menu {
-	position: absolute;
-	margin-left: -160px;
+position: absolute;
+margin-left: -160px;
+margin-top: 20px;
 }
 
 #facebook-header-login .elgg-menu > li {


### PR DESCRIPTION
By @jljvdm, "The label "Register" is overlapping the password box in Chrome & FireFox on Debian Linux.
The fix is tested on Chrome on Windows 8.1 & Linux, Firefox an IE 11 on Windows 8.1"
